### PR TITLE
Pdijksta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ scripts/
 .ipynb_checkpoints
 Pyecltest.mat
 *.png
+*.swp

--- a/gen_photoemission_class.py
+++ b/gen_photoemission_class.py
@@ -88,6 +88,11 @@ class photoemission:
         if y0_refl!=0.:
             raise ValueError('The case y0_refl!=0 is NOT IMPLEMETED yet!!!!')
         
+        x0_refl_np_arr = np.array([x0_refl])
+        y0_refl_np_arr = np.array([y0_refl])
+        if np.any(self.chamb.is_outside(x0_refl_np_arr, y0_refl_np_arr)):
+            raise ValueError('x0_refl, y0_refl is outside of the chamber!')
+
         print 'Done photoemission init.'
 
     def generate(self, MP_e, lambda_t, Dt):


### PR DESCRIPTION
A consistency test is added for 'gen_photoemission_class.py'.

If the point (x0_refl, y0_refl) as specified in the input files is outside the chamber, a ValueError is raised.
This is necessary since this point is used as as (x_in, y_in) of new MPs, see line 140 of 'gen_photoemission_class.py'.