### PR TITLE
Feature/arch linux compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ cern:
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m boris_step -c boris_step.f
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m vectsum -c vectsum.f
 local:
-	f2py -m rhocompute -c compute_rho.f
-	f2py -m int_field_for -c interp_field_for.f
-	f2py -m hist_for -c compute_hist.f
-	f2py -m seg_impact -c update_seg_impact.f
-	f2py -m errffor -c errfff.f
-	f2py -m boris_step -c boris_step.f
-	f2py -m vectsum -c vectsum.f
+	f2py2 -m rhocompute -c compute_rho.f
+	f2py2 -m int_field_for -c interp_field_for.f
+	f2py2 -m hist_for -c compute_hist.f
+	f2py2 -m seg_impact -c update_seg_impact.f
+	f2py2 -m errffor -c errfff.f
+	f2py2 -m boris_step -c boris_step.f
+	f2py2 -m vectsum -c vectsum.f

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+
+.PHONY: local cern all
+
+# On arch linux, the command f2py2 has to be used for python2 programs such as PyECLOUD.
+# On ubuntu, there is no command called f2py2
+F2PY2_EXIST := $(shell command -v f2py2 2> /dev/null)
+
+ifdef F2PY2_EXIST
+		F2PY = f2py2
+else
+		F2PY = f2py
+endif
+
+
 all:local
 
 cern:
@@ -9,10 +23,10 @@ cern:
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m boris_step -c boris_step.f
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m vectsum -c vectsum.f
 local:
-	f2py2 -m rhocompute -c compute_rho.f
-	f2py2 -m int_field_for -c interp_field_for.f
-	f2py2 -m hist_for -c compute_hist.f
-	f2py2 -m seg_impact -c update_seg_impact.f
-	f2py2 -m errffor -c errfff.f
-	f2py2 -m boris_step -c boris_step.f
-	f2py2 -m vectsum -c vectsum.f
+	$(F2PY) -m rhocompute -c compute_rho.f
+	$(F2PY) -m int_field_for -c interp_field_for.f
+	$(F2PY) -m hist_for -c compute_hist.f
+	$(F2PY) -m seg_impact -c update_seg_impact.f
+	$(F2PY) -m errffor -c errfff.f
+	$(F2PY) -m boris_step -c boris_step.f
+	$(F2PY) -m vectsum -c vectsum.f

--- a/cythonize
+++ b/cythonize
@@ -3,4 +3,4 @@
 #compile flags and link flags
 #CFLAGS="-Iinclude -fPIC"  \
 #LDFLAGS="-Llib "     \
-    python setup.py build_ext -i
+    python2 setup.py build_ext -i


### PR DESCRIPTION
python3 is the default python version on Arch Linux (boo), and f2py creates python3 binaries.
This change lets the Makefile detect whether the command f2py2 is available: yes on Arch, no on other distributions.