### PR TITLE
Bug fix

### DIFF
--- a/sec_emission_model_accurate_low_ene.py
+++ b/sec_emission_model_accurate_low_ene.py
@@ -106,8 +106,7 @@ class SEY_model_acc_low_ene(SEY_model_ECLOUD):
             flag_elast = (rand(len(ref_prob)) < ref_prob)
             flag_truesec = ~(flag_elast)
 
-            nel_emit = nel_impact
+            nel_emit = nel_impact.copy()
             nel_emit[flag_truesec] = nel_impact[flag_truesec] * beta_ts[flag_truesec]
 
             return nel_emit, flag_elast, flag_truesec
-


### PR DESCRIPTION
Without the .copy() the extracted SEY curves never reached above 1 since nel_impact was overwritten.