### PR TITLE
Replace boolean indexing in impact management

### DIFF
--- a/MP_system.py
+++ b/MP_system.py
@@ -557,8 +557,8 @@ class MP_system:
             dict_MP_init = sio.loadmat(filename_MPs)
         else:
             dict_MP_init = filename_MPs
-
-        Nint_new_MP = int(dict_MP_init['N_mp'])
+        
+        Nint_new_MP = int(dict_MP_init['N_mp'].item() if hasattr(dict_MP_init['N_mp'],"item") else dict_MP_init['N_mp'])
 
         self.x_mp[self.N_mp:self.N_mp + Nint_new_MP] = np.squeeze(dict_MP_init['x_mp'])
         self.y_mp[self.N_mp:self.N_mp + Nint_new_MP] = np.squeeze(dict_MP_init['y_mp'])

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ cern:
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m boris_step -c boris_step.f
 	/afs/cern.ch/project/uslarp/opt/lxplus64/Python-2.7.2/bin/f2py -m vectsum -c vectsum.f
 local:
-	$(F2PY) -m rhocompute -c compute_rho.f
-	$(F2PY) -m int_field_for -c interp_field_for.f
-	$(F2PY) -m hist_for -c compute_hist.f
-	$(F2PY) -m seg_impact -c update_seg_impact.f
-	$(F2PY) -m errffor -c errfff.f
-	$(F2PY) -m boris_step -c boris_step.f
-	$(F2PY) -m vectsum -c vectsum.f
+	$(F2PY) -m rhocompute -c --backend meson compute_rho.f
+	$(F2PY) -m int_field_for -c --backend meson interp_field_for.f
+	$(F2PY) -m hist_for -c --backend meson compute_hist.f
+	$(F2PY) -m seg_impact -c --backend meson update_seg_impact.f
+	$(F2PY) -m errffor -c --backend meson errfff.f
+	$(F2PY) -m boris_step -c --backend meson boris_step.f
+	$(F2PY) -m vectsum -c --backend meson vectsum.f

--- a/impact_management_class.py
+++ b/impact_management_class.py
@@ -54,8 +54,6 @@ import numpy as np
 from . import hist_for as histf
 from . import seg_impact as segi
 from scipy.constants import e as qe
-# from line_profiler import profile
-
 
 class impact_management(object):
     def __init__(
@@ -171,7 +169,6 @@ class impact_management(object):
     def reset_lifetime_hist_line(self):
         self.lifetime_hist_line *= 0.
 
-    # @profile
     def backtrack_and_second_emiss(self, old_pos, MP_e, tt_curr=None):
 
         self.Nel_impact_last_step = 0.
@@ -217,19 +214,19 @@ class impact_management(object):
             flag_impact[:N_mp_old] = chamb.is_outside(
                 x_mp[0:N_mp_old], y_mp[0:N_mp_old])
             
-            idx = np.nonzero(flag_impact)[0]  
+            idx = np.flatnonzero(flag_impact)
             Nimpact = int(np.sum(flag_impact))
 
             if Nimpact > 0:
 
                 # load segment endpoints
-                x_in = x_mp_old[idx] #flag_impact[:N_mp_old]
-                y_in = y_mp_old[idx] #flag_impact[:N_mp_old]
-                z_in = z_mp_old[idx] #flag_impact[:N_mp_old]
-                # print(N_mp_old)
-                x_out = x_mp[idx] #flag_impact
-                y_out = y_mp[idx] #flag_impact
-                z_out = z_mp[idx] #flag_impact
+                x_in = x_mp_old[idx]
+                y_in = y_mp_old[idx]
+                z_in = z_mp_old[idx]
+
+                x_out = x_mp[idx]
+                y_out = y_mp[idx]
+                z_out = z_mp[idx]
 
                 # backtracking and surface normal generation
                 [x_impact, y_impact, z_impact, Norm_x, Norm_y, i_found] =\
@@ -237,20 +234,20 @@ class impact_management(object):
                         x_in, y_in, z_in, x_out, y_out, z_out)
 
                 # load velocities and charges
-                vx_impact = vx_mp[idx] #flag_impact
-                vy_impact = vy_mp[idx] #flag_impact
-                vz_impact = vz_mp[idx] #flag_impact
-                nel_impact = nel_mp[idx] #flag_impact
+                vx_impact = vx_mp[idx]
+                vy_impact = vy_mp[idx]
+                vz_impact = vz_mp[idx]
+                nel_impact = nel_mp[idx]
 
                 # add to lifetime histogram
                 if self.flag_lifetime_hist:
-                    lifetime_impact = tt_curr - MP_e.t_last_impact[idx] #flag_impact
+                    lifetime_impact = tt_curr - MP_e.t_last_impact[idx]
                     if sum(MP_e.t_last_impact[idx] > 0) > 0:
-                        histf.compute_hist(lifetime_impact[MP_e.t_last_impact[idx] > 0], #flag_impact
-                                           nel_impact[MP_e.t_last_impact[idx] > 0], #flag_impact
+                        histf.compute_hist(lifetime_impact[MP_e.t_last_impact[idx] > 0],
+                                           nel_impact[MP_e.t_last_impact[idx] > 0], 
                                            0., Dt_lifetime_hist, self.lifetime_hist_line)
 
-                    MP_e.t_last_impact[idx] = tt_curr #flag_impact
+                    MP_e.t_last_impact[idx] = tt_curr
 
                 # compute impact velocities, energy and angle
                 v_impact_mod = np.sqrt(
@@ -313,13 +310,13 @@ class impact_management(object):
                 self.Nel_emit_last_step = np.sum(nel_emit_tot_events)
 
                 # Replace old MPs
-                x_mp[idx] = x_replace #flag_impact
-                y_mp[idx] = y_replace #flag_impact
-                z_mp[idx] = z_replace #flag_impact
-                vx_mp[idx] = vx_replace #flag_impact
-                vy_mp[idx] = vy_replace #flag_impact
-                vz_mp[idx] = vz_replace #flag_impact
-                nel_mp[idx] = nel_replace #flag_impact
+                x_mp[idx] = x_replace
+                y_mp[idx] = y_replace
+                z_mp[idx] = z_replace
+                vx_mp[idx] = vx_replace
+                vy_mp[idx] = vy_replace
+                vz_mp[idx] = vz_replace
+                nel_mp[idx] = nel_replace
 
                 # subtract replaced macroparticles
                 v_replace_mod = np.sqrt(

--- a/impact_management_class.py
+++ b/impact_management_class.py
@@ -54,6 +54,7 @@ import numpy as np
 from . import hist_for as histf
 from . import seg_impact as segi
 from scipy.constants import e as qe
+# from line_profiler import profile
 
 
 class impact_management(object):
@@ -215,18 +216,20 @@ class impact_management(object):
             # detect impact
             flag_impact[:N_mp_old] = chamb.is_outside(
                 x_mp[0:N_mp_old], y_mp[0:N_mp_old])
-
+            
+            idx = np.nonzero(flag_impact)[0]  
             Nimpact = int(np.sum(flag_impact))
 
             if Nimpact > 0:
 
                 # load segment endpoints
-                x_in = x_mp_old[flag_impact[:N_mp_old]]
-                y_in = y_mp_old[flag_impact[:N_mp_old]]
-                z_in = z_mp_old[flag_impact[:N_mp_old]]
-                x_out = x_mp[flag_impact]
-                y_out = y_mp[flag_impact]
-                z_out = z_mp[flag_impact]
+                x_in = x_mp_old[idx] #flag_impact[:N_mp_old]
+                y_in = y_mp_old[idx] #flag_impact[:N_mp_old]
+                z_in = z_mp_old[idx] #flag_impact[:N_mp_old]
+                # print(N_mp_old)
+                x_out = x_mp[idx] #flag_impact
+                y_out = y_mp[idx] #flag_impact
+                z_out = z_mp[idx] #flag_impact
 
                 # backtracking and surface normal generation
                 [x_impact, y_impact, z_impact, Norm_x, Norm_y, i_found] =\
@@ -234,20 +237,20 @@ class impact_management(object):
                         x_in, y_in, z_in, x_out, y_out, z_out)
 
                 # load velocities and charges
-                vx_impact = vx_mp[flag_impact]
-                vy_impact = vy_mp[flag_impact]
-                vz_impact = vz_mp[flag_impact]
-                nel_impact = nel_mp[flag_impact]
+                vx_impact = vx_mp[idx] #flag_impact
+                vy_impact = vy_mp[idx] #flag_impact
+                vz_impact = vz_mp[idx] #flag_impact
+                nel_impact = nel_mp[idx] #flag_impact
 
                 # add to lifetime histogram
                 if self.flag_lifetime_hist:
-                    lifetime_impact = tt_curr - MP_e.t_last_impact[flag_impact]
-                    if sum(MP_e.t_last_impact[flag_impact] > 0) > 0:
-                        histf.compute_hist(lifetime_impact[MP_e.t_last_impact[flag_impact] > 0],
-                                           nel_impact[MP_e.t_last_impact[flag_impact] > 0],
+                    lifetime_impact = tt_curr - MP_e.t_last_impact[idx] #flag_impact
+                    if sum(MP_e.t_last_impact[idx] > 0) > 0:
+                        histf.compute_hist(lifetime_impact[MP_e.t_last_impact[idx] > 0], #flag_impact
+                                           nel_impact[MP_e.t_last_impact[idx] > 0], #flag_impact
                                            0., Dt_lifetime_hist, self.lifetime_hist_line)
 
-                    MP_e.t_last_impact[flag_impact] = tt_curr
+                    MP_e.t_last_impact[idx] = tt_curr #flag_impact
 
                 # compute impact velocities, energy and angle
                 v_impact_mod = np.sqrt(
@@ -310,13 +313,13 @@ class impact_management(object):
                 self.Nel_emit_last_step = np.sum(nel_emit_tot_events)
 
                 # Replace old MPs
-                x_mp[flag_impact] = x_replace
-                y_mp[flag_impact] = y_replace
-                z_mp[flag_impact] = z_replace
-                vx_mp[flag_impact] = vx_replace
-                vy_mp[flag_impact] = vy_replace
-                vz_mp[flag_impact] = vz_replace
-                nel_mp[flag_impact] = nel_replace
+                x_mp[idx] = x_replace #flag_impact
+                y_mp[idx] = y_replace #flag_impact
+                z_mp[idx] = z_replace #flag_impact
+                vx_mp[idx] = vx_replace #flag_impact
+                vy_mp[idx] = vy_replace #flag_impact
+                vz_mp[idx] = vz_replace #flag_impact
+                nel_mp[idx] = nel_replace #flag_impact
 
                 # subtract replaced macroparticles
                 v_replace_mod = np.sqrt(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import numpy
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup, Extension
 from Cython.Build import cythonize
 
 setup(


### PR DESCRIPTION
Quick fix which speeds up buildup simulations by ~30%. 

Buildup tests passed (within margin of error), results can be found in:
https://cernbox.cern.ch/s/RhgZEzUFUGBhDCE

In the above link, the left plots correspond to the previous version of PyECLOUD and the right to this version with the changes applied.